### PR TITLE
Fixes applied to command line options parsing to stop program crashing

### DIFF
--- a/doc/fapolicyd.8
+++ b/doc/fapolicyd.8
@@ -23,7 +23,7 @@ leave the daemon in the foreground for debugging. Event information is written t
 the daemon will allow file access regardless of the policy decision. This is useful for debugging rules before making them permanent.
 .TP
 .B \-\-boost\ NN
-increase the daemon's scheduling priority by this much. The number should be positive and less than 20. The default boost is 10.
+increase the daemon's scheduling priority by this much. The number should be positive and less than or equal to 20. The default boost is 10.
 .TP
 .B \-\-queue\ NNNN
 the internal queue of pending decisions is set by this number. It should be a positive number. The default size is 1024.


### PR DESCRIPTION
Some minor fixes to the command line options processing logic. Found that passing values to the options 'boost' and 'queue' had caused the program to crash with a segmentation fault. Seeing as though most these command line options can also be set via the fapolicyd configuration file, I thought it'd make sense to align the logic with what has been defined for the parsers within src/daemon-config.c (specifically referring to the setting of the niceness here).

Also, rather than actually just assigning gid = uid, I thought it'd be better actually obtaining the primary group id of the user and using that when the 'user' command line option is used.