### PR TITLE
Mount load update

### DIFF
--- a/src/mounts.c
+++ b/src/mounts.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <stdlib.h>
 #include <string.h>
+#include <unistd.h>
 #include <limits.h>
 #include <errno.h>
 #include <sys/stat.h>
@@ -131,29 +132,45 @@ int load_mounts(void)
 	while (get_line(f, buf, PATH_MAX)) {
 		if (buf[0] != '#') {
 			char *ptr = buf;
+
 			while (*ptr == ' ')
 				ptr++;
-			if (*ptr != 0) {
+
+			/* Only proceed if it appears to be an absolute path */
+			if (*ptr == '/') {
 				struct stat sb;
 
-				if (stat(ptr, &sb) == 0) {
-					if (!S_ISDIR(sb.st_mode)) {
-						msg(LOG_ERR,
-				    "mount point %s is not a directory", ptr);
-						exit(1);
-					}
+				if (stat(ptr, &sb) == -1) {
+					msg(LOG_INFO, "Invalid entry \"%s\". "
+						"Failed to stat object, %s."
+						" Skipping", ptr, 
+						strerror(errno));
+					continue; /* Don't return to caller */
 				}
+
+				if (!S_ISDIR(sb.st_mode)) {
+					msg(LOG_INFO, "Invalid entry \"%s\". "
+						"Is not directory. Skipping",
+						 ptr);
+					continue; /* Don't return to caller */
+				}
+
 				mounts_append(&mounts, ptr, lineno);
 			}
 		}
+
 		lineno++;
 	}
-	fclose(f);
 
+	fclose(f);
+	close(fd);
+
+	/* Only return true if no mounts found in configuration file */
 	if (mounts.cnt == 0) { 
 		msg(LOG_INFO, "No mount points - exiting");
 		return 1;
 	}
+
 	return 0;
 }
 


### PR DESCRIPTION
- Added logic for skipping invalid entries within the configuration file. If no _valid_ entries are able to be determined within the mount configuration file, only then does the program exit with an error.

- Slightly changed the logic to only perform additional processing on lines where the first character in that line begins with '/', which essentially represents a mount/absolute path.